### PR TITLE
chore: Increase Max Slippage For Stable & LST

### DIFF
--- a/dynamic_slippage_config.json
+++ b/dynamic_slippage_config.json
@@ -3,7 +3,7 @@
     {
       "name": "stable",
       "range": {
-        "min": 5,
+        "min": 20,
         "max": 100
       },
       "mints": [
@@ -25,11 +25,11 @@
     {
       "name": "lst",
       "range": {
-        "min": 50,
+        "min": 100,
         "max": 300
       },
       "pairRange": {
-        "min": 20,
+        "min": 50,
         "max": 300
       },
       "mints": [
@@ -113,8 +113,8 @@
     {
       "name": "bluechip",
       "range": {
-        "min": 50,
-        "max": 150
+        "min": 100,
+        "max": 300
       },
       "mints": [
         "JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN",

--- a/dynamic_slippage_config.json
+++ b/dynamic_slippage_config.json
@@ -4,7 +4,7 @@
       "name": "stable",
       "range": {
         "min": 5,
-        "max": 80
+        "max": 100
       },
       "mints": [
         "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
@@ -26,11 +26,11 @@
       "name": "lst",
       "range": {
         "min": 50,
-        "max": 100
+        "max": 300
       },
       "pairRange": {
         "min": 20,
-        "max": 80
+        "max": 300
       },
       "mints": [
         "So11111111111111111111111111111111111111112",


### PR DESCRIPTION
# Problem
Our max slippage is being hit and swaps are still failing. 

# Solution
We'll increase the max slippage allowed for dynamic slippage for both Stables & LST