### PR TITLE
chore: Increase Max Slippage For Stables

### DIFF
--- a/dynamic_slippage_config.json
+++ b/dynamic_slippage_config.json
@@ -4,7 +4,7 @@
       "name": "stable",
       "range": {
         "min": 20,
-        "max": 100
+        "max": 200
       },
       "mints": [
         "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",


### PR DESCRIPTION
# Problem
- Experiencing slippage higher than 100bps so swaps between stables are still failing

# Solution
- Increase it to 200bps