### PR TITLE
Increase Slippage For Jup Token

### DIFF
--- a/dynamic_slippage_config.json
+++ b/dynamic_slippage_config.json
@@ -112,8 +112,8 @@
     {
       "name": "bluechip",
       "range": {
-        "min": 100,
-        "max": 300
+        "min": 200,
+        "max": 400
       },
       "mints": [
         "JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN",

--- a/dynamic_slippage_config.json
+++ b/dynamic_slippage_config.json
@@ -18,7 +18,8 @@
         "8qJSyQprMC57TWKaYEmetUR3UUiTP2M3hXdcvFhkZdmv",
         "DEkqHyPN7GMRJ5cArtQFAWefqbZb33Hyf6s5iCwjEonT",
         "2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo",
-        "USDSwr9ApdHk5bvJKMjzff41FfuX8bSxdKcR81vTwcA"
+        "USDSwr9ApdHk5bvJKMjzff41FfuX8bSxdKcR81vTwcA",
+        "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB"
       ]
     },
     {


### PR DESCRIPTION
Jup token `JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN` is in the `bluechip` category.