### PR TITLE
Feat: Add Category To Exclude Tokens From Being Used As Intermediates

### DIFF
--- a/slippage_config.json
+++ b/slippage_config.json
@@ -34,6 +34,13 @@
                 "min": 100,
                 "max": 1000
             }
+        },
+        {
+            "name": "pump_new_graduated",
+            "range": {
+                "min": 500,
+                "max": 1000
+            }
         }
     ]
 }

--- a/token_categories.json
+++ b/token_categories.json
@@ -126,5 +126,5 @@
             ]
         }
     ],
-    "excluded_tokens": []
+    "excluded_from_intermediate_hop_mints": []
 }

--- a/token_categories.json
+++ b/token_categories.json
@@ -125,5 +125,6 @@
                 "jtojtomepa8beP8AuQc6eXt5FriJwfFMwQx2v2f9mCL"
             ]
         }
-    ]
+    ],
+    "excluded_tokens": []
 }


### PR DESCRIPTION
# Problem
- There's no way to exclude tokens from being used as intermediate hops without taking them out from the token category in this current setup.
- Pumpfun tokens min max are hardcoded in code.

# Solution
- Add a new category to exclude tokens which shouldn't be used as intermediates
- Add a new slippage config for pump tokens which are newly graduated