### PR TITLE
chore: Add $ARC to Bluechip Category

### DIFF
--- a/dynamic_slippage_config.json
+++ b/dynamic_slippage_config.json
@@ -133,7 +133,8 @@
         "2qEHjDLDLbuBgRYvsxhc5D6uDWAivNFZGan56P1tpump",
         "GJtJuWD9qYcCkrwMBmtY1tpapV1sKfB2zUv9Q4aqpump",
         "5mbK36SZ7J19An8jFochhQS4of8g6BwUjbeCSxBSoWdp",
-        "jtojtomepa8beP8AuQc6eXt5FriJwfFMwQx2v2f9mCL"
+        "jtojtomepa8beP8AuQc6eXt5FriJwfFMwQx2v2f9mCL",
+        "61V8vBaqAGMpgDQi4JcAwo1dmBGHsyhzodcPqnEVpump"
       ]
     },
     {

--- a/token_categories.json
+++ b/token_categories.json
@@ -122,7 +122,8 @@
                 "2qEHjDLDLbuBgRYvsxhc5D6uDWAivNFZGan56P1tpump",
                 "GJtJuWD9qYcCkrwMBmtY1tpapV1sKfB2zUv9Q4aqpump",
                 "5mbK36SZ7J19An8jFochhQS4of8g6BwUjbeCSxBSoWdp",
-                "jtojtomepa8beP8AuQc6eXt5FriJwfFMwQx2v2f9mCL"
+                "jtojtomepa8beP8AuQc6eXt5FriJwfFMwQx2v2f9mCL",
+                "61V8vBaqAGMpgDQi4JcAwo1dmBGHsyhzodcPqnEVpump"
             ]
         }
     ],


### PR DESCRIPTION
# Problem
We're unable to route to new tokens which are launched with $ARC as its trading pair such as this https://app.meteora.ag/dlmm/54vGmK8cq5oaC1x17xinSTMjBQFVsmGgcXqDeMUjpDt9 because we're restricting intermediate routing to only a list of tokens

# Short Term Solution
Add $arc to the blue chip category

# Long Term Solution
[Expansion of intermediate tokens dynamically when we route](https://discord.com/channels/1274198275347452028/1274200974881329263/1334856459170611262)