### PR TITLE
fix: raise stable min slippage

### DIFF
--- a/dynamic_slippage_config.json
+++ b/dynamic_slippage_config.json
@@ -3,7 +3,7 @@
     {
       "name": "stable",
       "range": {
-        "min": 5,
+        "min": 10,
         "max": 80
       },
       "mints": [

--- a/slippage_config.json
+++ b/slippage_config.json
@@ -10,7 +10,7 @@
         {
             "name": "stable",
             "range": {
-                "min": 5,
+                "min": 10,
                 "max": 80
             }
         },


### PR DESCRIPTION
- Dynamic slippage doesn't work too well now as /quote and /swap is called with minimal delay
- Slippage raise coincides with eyeball test (0.05% fails quite often, but 0.1% works most of the time)