### PR TITLE
chore: Add virtual into our blue chip token category

### DIFF
--- a/dynamic_slippage_config.json
+++ b/dynamic_slippage_config.json
@@ -134,7 +134,8 @@
         "GJtJuWD9qYcCkrwMBmtY1tpapV1sKfB2zUv9Q4aqpump",
         "5mbK36SZ7J19An8jFochhQS4of8g6BwUjbeCSxBSoWdp",
         "jtojtomepa8beP8AuQc6eXt5FriJwfFMwQx2v2f9mCL",
-        "61V8vBaqAGMpgDQi4JcAwo1dmBGHsyhzodcPqnEVpump"
+        "61V8vBaqAGMpgDQi4JcAwo1dmBGHsyhzodcPqnEVpump",
+        "3iQL8BFS2vE7mww4ehAqQHAsbmRNCrPxizWAT2Zfyr9y"
       ]
     },
     {

--- a/token_categories.json
+++ b/token_categories.json
@@ -123,7 +123,8 @@
                 "GJtJuWD9qYcCkrwMBmtY1tpapV1sKfB2zUv9Q4aqpump",
                 "5mbK36SZ7J19An8jFochhQS4of8g6BwUjbeCSxBSoWdp",
                 "jtojtomepa8beP8AuQc6eXt5FriJwfFMwQx2v2f9mCL",
-                "61V8vBaqAGMpgDQi4JcAwo1dmBGHsyhzodcPqnEVpump"
+                "61V8vBaqAGMpgDQi4JcAwo1dmBGHsyhzodcPqnEVpump",
+                "3iQL8BFS2vE7mww4ehAqQHAsbmRNCrPxizWAT2Zfyr9y"
             ]
         }
     ],


### PR DESCRIPTION
# Problem
There will be more new token launches against $virtual soon. Without adding it to the `bluechip` category, we may not be able to route to those new tokens.

# Solution
Add $virtual https://solscan.io/token/3iQL8BFS2vE7mww4ehAqQHAsbmRNCrPxizWAT2Zfyr9y into `bluechips`