### PR TITLE
chore: Move Pumpfun 1st Hour Slippage Config Into Its Own

### DIFF
--- a/slippage_config.json
+++ b/slippage_config.json
@@ -55,6 +55,13 @@
                 "min": 300,
                 "max": 2000
             }
+        },
+        {
+            "name": "pump_new_graduate_first_hour",
+            "range": {
+                "min": 1000,
+                "max": 2000
+            }
         }
     ]
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,8 @@ mod tests {
                 "default",
                 "pump_new_graduate",
                 "degen",
-                "new_token"
+                "new_token",
+                "pump_new_graduate_first_hour"
             ]
         );
     }


### PR DESCRIPTION
We are multiplying the minimum in `pumpfun_new_graduate` slippage config by 2 for tokens which have just graduated within the first hour.

Instead of that, we'll make that into its own slippage config category