### PR TITLE
fix: add memesol lst

### DIFF
--- a/token_categories.json
+++ b/token_categories.json
@@ -100,7 +100,8 @@
                 "Bybit2vBJGhPF52GBdNaQfUJ6ZpThSgHBobjWZpLPb4B",
                 "5oVNBeEEQvYi1cX3ir8Dx5n1P7pdxydbGF2X4TxVusJm",
                 "7dHbWXmci3dT8UFYWYZweBLXgycu7Y3iL6trKn1Y7ARj",
-                "BNso1VUJnh4zcfpZa6986Ea66P6TCp59hvtNJ8b1X85"
+                "BNso1VUJnh4zcfpZa6986Ea66P6TCp59hvtNJ8b1X85",
+                "meme9VKXNNxquqQgvXTAauiHYP6giqrZHA2Tjzf9umy"
             ]
         },
         {


### PR DESCRIPTION
- CA: https://app.sanctum.so/memeSOL and https://solscan.io/token/meme9VKXNNxquqQgvXTAauiHYP6giqrZHA2Tjzf9umy
- Majority of SYMMETRA liquidity is pooled with SYMMETRA/memeSOL
- However, routing from SOL will not use memeSOL since memeSOL is not in the list of LSTs
- This PR adds memeSOL into the list of LSTs so that memeSOL can be used as an intermediate token

![image](https://github.com/user-attachments/assets/8f900ea0-24f1-4049-bd27-e268a62f3849)

![image](https://github.com/user-attachments/assets/ab09b990-736e-4b90-bffb-c7a2d935eacf)
