### PR TITLE
chore: Reduce solana min slippage to 15bps

### DIFF
--- a/slippage_config.json
+++ b/slippage_config.json
@@ -3,7 +3,7 @@
         {
             "name": "solana",
             "range": {
-                "min": 20,
+                "min": 15,
                 "max": 100
             }
         },


### PR DESCRIPTION
Reducing slippage min for solana category to 15bps