### PR TITLE
feat: new category for selling and buying in degen category

### DIFF
--- a/slippage_config.json
+++ b/slippage_config.json
@@ -62,6 +62,20 @@
                 "min": 1000,
                 "max": 2000
             }
+        },
+        {
+            "name": "degen_buy",
+            "range": {
+                "min": 1000,
+                "max": 2500
+            }
+        },
+        {
+            "name": "degen_sell",
+            "range": {
+                "min": 1000,
+                "max": 5000
+            }
         }
     ]
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,9 @@ mod tests {
                 "pump_new_graduate",
                 "degen",
                 "new_token",
-                "pump_new_graduate_first_hour"
+                "pump_new_graduate_first_hour",
+                "degen_buy",
+                "degen_sell"
             ]
         );
     }


### PR DESCRIPTION
# Problem
degen category is too broad and doesn't capture aggressive selling and buying of tokens from the `default` category.

# Solution
2 new categories for buy and sell of default tokens.