### PR TITLE
chore: Add trump coin into bluechips list

### DIFF
--- a/token_categories.json
+++ b/token_categories.json
@@ -127,7 +127,8 @@
                 "5mbK36SZ7J19An8jFochhQS4of8g6BwUjbeCSxBSoWdp",
                 "jtojtomepa8beP8AuQc6eXt5FriJwfFMwQx2v2f9mCL",
                 "61V8vBaqAGMpgDQi4JcAwo1dmBGHsyhzodcPqnEVpump",
-                "3iQL8BFS2vE7mww4ehAqQHAsbmRNCrPxizWAT2Zfyr9y"
+                "3iQL8BFS2vE7mww4ehAqQHAsbmRNCrPxizWAT2Zfyr9y",
+                "6p6xgHyF7AeE6TZkSmFsko444wqoP15icUSqi2jfGiPN"
             ]
         }
     ],


### PR DESCRIPTION
There will be a token launch on DBC that will be paired with $trump. We'll have to add $trump into the bluechips list in order to make that market routable.

$trump (https://jup.ag/tokens/6p6xgHyF7AeE6TZkSmFsko444wqoP15icUSqi2jfGiPN) has a high marketcap and trading volume so it should be okay.